### PR TITLE
BUG/15 회원가입 외 User 서비스 public path 해제

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check branch name format
         run: |
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          REGEX="^(feat|fix|refactor|docs|chore|test)\/[0-9]+-.+$"
+          REGEX="^(feat|fix|refactor|docs|chore|test|bug)\/[0-9]+-.+$"
 
           if [[ ! $BRANCH_NAME =~ $REGEX ]]; then
             echo "❌ ERROR: 브랜치 이름 형식이 틀렸습니다!"

--- a/src/main/java/com/pagely/gateway/domain/exception/BusinessException.java
+++ b/src/main/java/com/pagely/gateway/domain/exception/BusinessException.java
@@ -1,0 +1,18 @@
+package com.pagely.gateway.domain.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String detailMessage) {
+        super(detailMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/pagely/gateway/domain/exception/CommonErrorCode.java
+++ b/src/main/java/com/pagely/gateway/domain/exception/CommonErrorCode.java
@@ -1,0 +1,36 @@
+package com.pagely.gateway.domain.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 공통 에러 코드.
+ */
+@Getter
+public enum CommonErrorCode implements ErrorCode {
+
+    // 4xx
+    INVALID_INPUT("입력값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    RESOURCE_NOT_FOUND("요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED("인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    CONFLICT("요청이 현재 상태와 충돌합니다.", HttpStatus.CONFLICT),
+    UNSUPPORTED_MEDIA_TYPE("지원하지 않는 미디어 타입입니다.", HttpStatus.UNSUPPORTED_MEDIA_TYPE),
+    TOO_MANY_REQUESTS("요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.", HttpStatus.TOO_MANY_REQUESTS),
+
+    // 5xx
+    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    SERVICE_UNAVAILABLE("서비스를 일시적으로 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    EVENT_PUBLISH_FAILURE("이벤트 발행에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    CommonErrorCode(String message, HttpStatus httpStatus) {
+        this.code = this.name();
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/com/pagely/gateway/domain/exception/ErrorCode.java
+++ b/src/main/java/com/pagely/gateway/domain/exception/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.pagely.gateway.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String getCode();
+
+    String getMessage();
+
+    HttpStatus getHttpStatus();
+}

--- a/src/main/java/com/pagely/gateway/domain/exception/ErrorResponse.java
+++ b/src/main/java/com/pagely/gateway/domain/exception/ErrorResponse.java
@@ -1,0 +1,42 @@
+package com.pagely.gateway.domain.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 에러 상세 정보 DTO.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    private String code;
+    private String message;
+    private List<FieldError> fieldErrors;
+
+    public static ErrorResponse of(String code, String message) {
+        return new ErrorResponse(code, message, null);
+    }
+
+    public static ErrorResponse of(String code, String message, List<FieldError> fieldErrors) {
+        return new ErrorResponse(code, message, fieldErrors);
+    }
+
+    /**
+     * Bean Validation 필드 오류 정보.
+     */
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(staticName = "of")
+    public static class FieldError {
+        private String field;
+        private Object rejectedValue;
+        private String reason;
+    }
+}

--- a/src/main/java/com/pagely/gateway/domain/exception/GatewayErrorCode.java
+++ b/src/main/java/com/pagely/gateway/domain/exception/GatewayErrorCode.java
@@ -1,0 +1,20 @@
+package com.pagely.gateway.domain.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum GatewayErrorCode implements ErrorCode {
+    INVALID_TOKEN_FORMAT("Authorization 헤더는 'Bearer {token}' 형식이어야 합니다.", HttpStatus.UNAUTHORIZED),
+    EMPTY_TOKEN("토큰이 비어있습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN("토큰이 유효하지 않거나 만료되었습니다.", HttpStatus.UNAUTHORIZED);
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    GatewayErrorCode(String message, HttpStatus httpStatus) {
+        this.code = this.name();
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/com/pagely/gateway/infrastructure/config/ErrorConfig.java
+++ b/src/main/java/com/pagely/gateway/infrastructure/config/ErrorConfig.java
@@ -1,0 +1,20 @@
+package com.pagely.gateway.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pagely.gateway.infrastructure.exception.GatewayExceptionHandler;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.annotation.Order;
+
+@Configuration
+public class ErrorConfig {
+
+    @Bean
+    @Primary  // 같은 타입의 빈이 여러 개일 때 이 녀석을 1순위로!
+    @Order(-2) // 기본 핸들러(-1)보다 높은 순위
+    public ErrorWebExceptionHandler gatewayExceptionHandler(ObjectMapper objectMapper) {
+        return new GatewayExceptionHandler(objectMapper);
+    }
+}

--- a/src/main/java/com/pagely/gateway/infrastructure/exception/GatewayExceptionHandler.java
+++ b/src/main/java/com/pagely/gateway/infrastructure/exception/GatewayExceptionHandler.java
@@ -1,0 +1,72 @@
+package com.pagely.gateway.infrastructure.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pagely.gateway.domain.exception.BusinessException;
+import com.pagely.gateway.domain.exception.CommonErrorCode;
+import com.pagely.gateway.domain.exception.ErrorCode;
+import com.pagely.gateway.domain.exception.ErrorResponse;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Gateway는 WebFlux 기반의 정적인 라이브러리 환경이기 때문에, 일반적인 MVC의 @RestControllerAdvice를 사용할 수 없습니다.
+ *
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class GatewayExceptionHandler implements ErrorWebExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+        log.info("[GatewayExceptionHandler] 진입 - 예외: {}", ex.getMessage()); // 이 로그가 찍히는지 확인이 핵심입니다!
+        ServerHttpResponse response = exchange.getResponse();
+
+        if (response.isCommitted()) {
+            return Mono.error(ex);
+        }
+
+        // 1. 에러 코드 추출
+        ErrorCode errorCode = determineErrorCode(ex);
+
+        // 2. 응답 설정
+        response.setStatusCode(errorCode.getHttpStatus());
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+        // 3. 공통 에러 응답 바디
+        Map<String, Object> apiResponse = Map.of(
+                "success", false,
+                "error", ErrorResponse.of(
+                        errorCode.getCode(),
+                        ex instanceof BusinessException ? ex.getMessage() : errorCode.getMessage()
+                )
+        );
+
+        return response.writeWith(Mono.fromSupplier(() -> {
+            try {
+                // 이 부분이 정확히 apiResponse 변수를 직렬화하는지 다시 확인!
+                byte[] bytes = objectMapper.writeValueAsBytes(apiResponse);
+                return response.bufferFactory().wrap(bytes);
+            } catch (Exception e) {
+                log.error("Error writing response", e);
+                return response.bufferFactory()
+                        .wrap("{\"success\":false,\"error\":{\"code\":\"INTERNAL_SERVER_ERROR\"}}".getBytes());
+            }
+        }));
+    }
+
+    private ErrorCode determineErrorCode(Throwable ex) {
+        if (ex instanceof BusinessException) {
+            return ((BusinessException) ex).getErrorCode();
+        }
+        // Gateway 자체에서 발생하는 예외들에 대한 매핑
+        return CommonErrorCode.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/src/main/java/com/pagely/gateway/infrastructure/security/AuthenticationFilter.java
+++ b/src/main/java/com/pagely/gateway/infrastructure/security/AuthenticationFilter.java
@@ -56,10 +56,11 @@ public class AuthenticationFilter implements GlobalFilter, Ordered {
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         ServerHttpRequest request = exchange.getRequest();
         String path = request.getURI().getPath();
+        HttpMethod method = request.getMethod();
 
-        // [1] Public Path 매칭 → 인증 우회
-        if (isPublicPath(path)) {
-            log.debug("Public path 인증 우회: {}", path);
+        // [1] Public Path 매칭 / 회원가입 경로 (POST /users/) → 인증 우회
+        if (isPublicPath(path) ||
+                "/api/v1/users".equals(path) && HttpMethod.POST.equals(method)) {
             return chain.filter(exchange);
         }
 

--- a/src/main/java/com/pagely/gateway/infrastructure/security/AuthenticationFilter.java
+++ b/src/main/java/com/pagely/gateway/infrastructure/security/AuthenticationFilter.java
@@ -1,23 +1,18 @@
 package com.pagely.gateway.infrastructure.security;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pagely.gateway.domain.exception.BusinessException;
+import com.pagely.gateway.domain.exception.CommonErrorCode;
+import com.pagely.gateway.domain.exception.GatewayErrorCode;
 import io.jsonwebtoken.JwtException;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
-import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.server.ServerWebExchange;
@@ -49,7 +44,6 @@ public class AuthenticationFilter implements GlobalFilter, Ordered {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtProperties jwtProperties;
-    private final ObjectMapper objectMapper;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
@@ -67,24 +61,22 @@ public class AuthenticationFilter implements GlobalFilter, Ordered {
         // [2] Authorization 헤더 추출
         String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
         if (authHeader == null || authHeader.isBlank()) {
-            return unauthorized(exchange, "MISSING_TOKEN", "인증 토큰이 필요합니다.");
+            return Mono.error(new BusinessException(CommonErrorCode.UNAUTHORIZED));
         }
 
         // [3] Bearer prefix 검증
         if (!authHeader.startsWith(BEARER_PREFIX)) {
-            return unauthorized(exchange, "INVALID_TOKEN_FORMAT",
-                    "Authorization 헤더는 'Bearer {token}' 형식이어야 합니다.");
+            return Mono.error(new BusinessException(GatewayErrorCode.INVALID_TOKEN_FORMAT));
         }
 
         String token = authHeader.substring(BEARER_PREFIX.length()).trim();
         if (token.isEmpty()) {
-            return unauthorized(exchange, "EMPTY_TOKEN", "토큰이 비어있습니다.");
+            return Mono.error(new BusinessException(GatewayErrorCode.EMPTY_TOKEN));
         }
 
         // [4] JWT 검증
         if (!jwtTokenProvider.validateToken(token)) {
-            return unauthorized(exchange, "INVALID_TOKEN",
-                    "토큰이 유효하지 않거나 만료되었습니다.");
+            return Mono.error(new BusinessException(GatewayErrorCode.INVALID_TOKEN));
         }
 
         // [5] 클레임 추출
@@ -93,7 +85,7 @@ public class AuthenticationFilter implements GlobalFilter, Ordered {
             claims = jwtTokenProvider.parseClaims(token);
         } catch (JwtException | IllegalStateException e) {
             log.warn("JWT 파싱 실패 (검증은 통과): {}", e.getMessage());
-            return unauthorized(exchange, "INVALID_TOKEN", "토큰 정보를 읽을 수 없습니다.");
+            return Mono.error(new BusinessException(GatewayErrorCode.INVALID_TOKEN));
         }
 
         // [6] 헤더 주입 후 다음 필터로
@@ -102,8 +94,8 @@ public class AuthenticationFilter implements GlobalFilter, Ordered {
                 .header(HEADER_USER_ROLE, claims.role())
                 .build();
 
-        log.debug("인증 성공: userId={}, role={}, path={}",
-                claims.userId(), claims.role(), path);
+/*        log.debug("인증 성공: userId={}, role={}, path={}",
+                claims.userId(), claims.role(), path);*/
 
         return chain.filter(exchange.mutate().request(mutatedRequest).build());
     }
@@ -118,32 +110,6 @@ public class AuthenticationFilter implements GlobalFilter, Ordered {
         }
         return publicPaths.stream()
                 .anyMatch(pattern -> pathMatcher.match(pattern, path));
-    }
-
-    /**
-     * 401 Unauthorized 응답 반환.
-     */
-    private Mono<Void> unauthorized(ServerWebExchange exchange, String error, String message) {
-        ServerHttpResponse response = exchange.getResponse();
-        response.setStatusCode(HttpStatus.UNAUTHORIZED);
-        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
-
-        Map<String, Object> body = Map.of(
-                "error", error,
-                "message", message,
-                "timestamp", LocalDateTime.now().toString()
-        );
-
-        try {
-            byte[] bytes = objectMapper.writeValueAsBytes(body);
-            DataBuffer buffer = response.bufferFactory().wrap(bytes);
-            return response.writeWith(Mono.just(buffer));
-        } catch (JsonProcessingException e) {
-            log.error("401 응답 직렬화 실패", e);
-            DataBuffer fallback = response.bufferFactory()
-                    .wrap("{\"error\":\"INTERNAL_ERROR\"}".getBytes(StandardCharsets.UTF_8));
-            return response.writeWith(Mono.just(fallback));
-        }
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,7 +87,6 @@ jwt:
   secret: ${JWT_SECRET}
   # 생성 명령: openssl rand -base64 64
   public-paths:
-    - /api/v1/users
     - /api/v1/auth/**
     - /actuator/**
     - /api/v1/payment/webhook


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- [BUG] 회원가입 외 User 서비스 public path 해제
- 회원가입에서만 JWT 검증 필터를 건너뛰도록 public 경로를 설정해야했는데,
/api/v1/users가 public path로 등록되어있었음.

- POST /users 요청에 한해서만 검증 처리 하지 않도록 Filter 화이트리스트 설정
- 에러 응답을 공통 모듈과 같은 형태로 수정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #15   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="734" height="425" alt="image" src="https://github.com/user-attachments/assets/6c5aa9ea-5419-4601-a5a7-4eea54ce0d6c" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 통합 오류 처리와 표준화된 JSON 오류 응답 추가
  * 공통 및 서비스별 오류 코드 체계 도입

* **개선사항**
  * 인증 실패 시 일관된 오류 코드와 메시지 반환
  * 필드 단위 검증 오류 정보를 오류 응답에 포함

* **기타**
  * 브랜치 네이밍 규칙에 bug/ 접두사 허용 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->