### PR TITLE
Feat/17 Auth Service 라우팅

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,53 +16,59 @@ spring:
       server:
         webflux:
           routes:
-            # AI Service
+            # Auth Service (19091)
+            - id: auth-service
+              uri: lb://authservice
+              predicates:
+                - Path=/api/v1/auth/**
+
+            # AI Service (19021)
             - id: ai-service
-              uri: http://localhost:19021
+              uri: lb://aiservice
               predicates:
                 - Path=/api/v1/ai/**
 
-            # User Service (유저 + 인증)
+            # User Service (19001)
             - id: user-service
-              uri: http://localhost:19001
+              uri: lb://userservice
               predicates:
-                - Path=/api/v1/users/**, /api/v1/auth/**
+                - Path=/api/v1/users/**
 
-            # Market Service (마켓)
+            # Market Service (19031)
             - id: market-service
               order: 2
-              uri: http://localhost:19031
+              uri: lb://marketservice
               predicates:
                 - Path=/api/v1/sale-posts/**, /api/v1/orders/**, /api/v1/sellers/**, /api/v1/buyers/**
 
-            # Payment Service (결제 + Webhook + 구매자 결제내역)
+            # Payment Service (19041 결제 + Webhook + 구매자 결제내역)
             - id: payment-service
               order: 1  # 숫자가 낮을수록 우선순위가 높음 (buyers)
-              uri: http://localhost:19041
+              uri: lb://paymentservice
               predicates:
                 - Path=/api/v1/payments/**, /api/v1/payment/webhook, /api/v1/buyers/me/payments
 
-            # Book Service (도서 조회/좋아요)
+            # Book Service (19051)
             - id: book-service
-              uri: http://localhost:19051
+              uri: lb://bookservice
               predicates:
                 - Path=/api/v1/books/**
 
-            # Report Service (독후감)
+            # Report Service (19061)
             - id: report-service
-              uri: http://localhost:19061
+              uri: lb://reportservice
               predicates:
                 - Path=/api/v1/reports/**
 
-            # Meeting Service (모임)
+            # Meeting Service (19011)
             - id: meeting-service
-              uri: http://localhost:19011
+              uri: lb://meetingservice
               predicates:
                 - Path=/api/v1/meetings/**
 
-            # Map Service (지도) : MVP 이후 수정
+            # Map Service (19071) : MVP 이후 수정
             - id: map-service
-              uri: http://localhost:19071
+              uri: lb://mapservice
               predicates:
                 - Path=/api/v1/map/**
 
@@ -74,7 +80,7 @@ spring:
 
 eureka:
   instance:
-    prefer-ip-address: false
+    prefer-ip-address: true
     hostname: ${HOSTNAME:localhost}
   client:
     register-with-eureka: true


### PR DESCRIPTION
Resolves:#17

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
-새 Auth Service 가 Gateway 통해 접근 가능하도록 라우팅 설정

- 서비스 이름 기반 라우팅 설정 (Load Balancer형식)
- Gateway 통해 /api/v1/auth/login 호출 성공
- 애플리케이션 이름 기반 동적 라우팅 설정 : uri: `http://localhost:19001` -> `lb://userservice`

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #17   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="863" height="583" alt="image" src="https://github.com/user-attachments/assets/6efc9070-6798-4a51-8756-49a8e20040b1" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.
